### PR TITLE
Rename tint color to match the new left tint color better

### DIFF
--- a/Sheeeeeeeeet/Appearance/ActionSheetSelectItemAppearance.swift
+++ b/Sheeeeeeeeet/Appearance/ActionSheetSelectItemAppearance.swift
@@ -20,12 +20,12 @@ open class ActionSheetSelectItemAppearance: ActionSheetItemAppearance {
     public override init(copy: ActionSheetItemAppearance) {
         super.init(copy: copy)
         selectedTextColor = copy.textColor
-        selectedTintColor = copy.tintColor
+        selectedTintColorRightIcon = copy.tintColor
         if let copy = copy as? ActionSheetSelectItemAppearance {
             selectedIcon = copy.selectedIcon
             selectedTextColor = copy.selectedTextColor ?? selectedTextColor
-            selectedTintColor = copy.selectedTintColor ?? selectedTintColor
-            selectedTintColorLeftIcon = copy.selectedTintColorLeftIcon ?? selectedTintColor
+            selectedTintColorRightIcon = copy.selectedTintColorRightIcon ?? selectedTintColorRightIcon
+            selectedTintColorLeftIcon = copy.selectedTintColorLeftIcon ?? selectedTintColorRightIcon
         }
     }
     
@@ -34,6 +34,6 @@ open class ActionSheetSelectItemAppearance: ActionSheetItemAppearance {
     
     public var selectedIcon: UIImage?
     public var selectedTextColor: UIColor?
-    public var selectedTintColor: UIColor?
+    public var selectedTintColorRightIcon: UIColor?
     public var selectedTintColorLeftIcon: UIColor?
 }

--- a/Sheeeeeeeeet/Items/ActionSheetSelectItem.swift
+++ b/Sheeeeeeeeet/Items/ActionSheetSelectItem.swift
@@ -55,7 +55,7 @@ open class ActionSheetSelectItem: ActionSheetItem {
         super.applyAppearance(to: cell)
         guard let appearance = selectAppearance else { return }
         cell.accessoryView = UIImageView(image: isSelected ? appearance.selectedIcon : nil)
-        cell.tintColor = isSelected ? appearance.selectedTintColor : appearance.tintColor
+        cell.tintColor = isSelected ? appearance.selectedTintColorRightIcon : appearance.tintColor
         cell.imageView?.tintColor = isSelected ? appearance.selectedTintColorLeftIcon : appearance.tintColor
         cell.textLabel?.textColor = isSelected ? appearance.selectedTextColor : appearance.textColor
     }

--- a/SheeeeeeeeetExample/Appearance/DemoAppearance.swift
+++ b/SheeeeeeeeetExample/Appearance/DemoAppearance.swift
@@ -40,12 +40,12 @@ class DemoAppearance: UIImageView {
         
         appearance.selectItem.selectedIcon = UIImage(named: "ic_checkmark")
         appearance.selectItem.selectedTextColor = green
-        appearance.selectItem.selectedTintColor = green
+        appearance.selectItem.selectedTintColorRightIcon = green
         appearance.selectItem.selectedTintColorLeftIcon = purple
         
         appearance.singleSelectItem.selectedIcon = UIImage(named: "ic_checkmark")
         appearance.singleSelectItem.selectedTextColor = purple
-        appearance.singleSelectItem.selectedTintColor = purple
+        appearance.singleSelectItem.selectedTintColorRightIcon = purple
         appearance.singleSelectItem.selectedTintColorLeftIcon = green
         
         appearance.linkItem.linkIcon = UIImage(named: "ic_arrow_right")


### PR DESCRIPTION
This is a small rename of the selectedTintColor to match the new left icon property name better. 