### PR TITLE
Add reload data before scrollToRow to avoid craches on iPad Mini 2

### DIFF
--- a/Sheeeeeeeeet/ActionSheet/ActionSheet+Scroll.swift
+++ b/Sheeeeeeeeet/ActionSheet/ActionSheet+Scroll.swift
@@ -24,6 +24,7 @@ public extension ActionSheet {
                 let index = (items.index { $0.isSelected == true })
                 else { return }
             let path = IndexPath(row: index, section: 0)
+            self?.itemsTableView?.reloadData()
             self?.itemsTableView?.scrollToRow(at: path, at: position, animated: animated)
         }
     }


### PR DESCRIPTION
We had some crashes on iPad mini 2 with `scrollToRow`. It can be avoided by doing a `reloadData()`. Since the itemsTableView is not accessible from outside **Sheeeeeeet** I had to add the reload in the extension method.

