### PR TITLE
Change default presentationStyle of ActionSheetStandardPresenter

### DIFF
--- a/Sheeeeeeeeet/Presenters/ActionSheetStandardPresenter.swift
+++ b/Sheeeeeeeeet/Presenters/ActionSheetStandardPresenter.swift
@@ -34,7 +34,7 @@ open class ActionSheetStandardPresenter: ActionSheetPresenter {
     
     public var events = ActionSheetPresenterEvents()
     public var isDismissableWithTapOnBackground = true
-    public var presentationStyle = PresentationStyle.keyWindow
+    public var presentationStyle = PresentationStyle.currentContext
     
     var actionSheet: ActionSheet?
     var animationDelay: TimeInterval = 0


### PR DESCRIPTION
Change default presentationstyle of ActionSheetStandardPresenter to currentContext instead of keyWindow.

This is to fix a bug in voice over with accessibility activated and presenting an actionsheeeeeeeeet from a modal.

This way we only have to change it to keyWindow when we really have to. In all other cases it is better to use currentContext. 