### PR TITLE
Make footer smaller in ActionSheets

### DIFF
--- a/Sheeeeeeeeet/ActionSheet/ActionSheet.swift
+++ b/Sheeeeeeeeet/ActionSheet/ActionSheet.swift
@@ -290,7 +290,7 @@ open class ActionSheet: UIViewController {
 private extension ActionSheet {
     
     func createFooter() -> UIView {
-        let view = UIView(frame: CGRect(x: 0, y: 0, width: 1, height: 1))
+        let view = UIView(frame: CGRect(x: 0, y: 0, width: 1, height: 0.1))
         view.backgroundColor = .clear
         return view
     }


### PR DESCRIPTION
This fix is to resolve an issue where a custom action sheet can get stuck in the wrong position after an orientation change. 

Since the footer is still there the line in the bottom of popovers is not shown.

An effect of this change is that some action sheets that previously was scrollable now are not. But they did not need to be scrollable, they only where because of this 1 point view.