### PR TITLE
Preserve `headerView` when using ActionSheetPopoverPresenter

### DIFF
--- a/Sheeeeeeeeet/Presenters/ActionSheetPopoverPresenter.swift
+++ b/Sheeeeeeeeet/Presenters/ActionSheetPopoverPresenter.swift
@@ -76,6 +76,7 @@ open class ActionSheetPopoverPresenter: NSObject, ActionSheetPresenter {
         sheet.headerViewContainer?.isHidden = !hasHeader
         sheet.buttonsTableView?.isHidden = true
         sheet.preferredContentSize.height = sheet.itemsHeight + (hasHeader ? sheet.headerViewContainerHeight!.constant + 15 : 0)
+        sheet.backgroundView?.backgroundColor = .white
         if #available(iOS 10.0, *) {
             refreshPopoverBackgroundColor()
         }

--- a/Sheeeeeeeeet/Presenters/ActionSheetPopoverPresenter.swift
+++ b/Sheeeeeeeeet/Presenters/ActionSheetPopoverPresenter.swift
@@ -72,7 +72,8 @@ open class ActionSheetPopoverPresenter: NSObject, ActionSheetPresenter {
         guard let sheet = actionSheet else { return }
         sheet.items = popoverItems(for: sheet)
         sheet.buttons = []
-        sheet.headerViewContainer?.isHidden = true
+        let hasHeader = sheet.headerView != nil
+        sheet.headerViewContainer?.isHidden = !hasHeader
         sheet.buttonsTableView?.isHidden = true
         sheet.preferredContentSize.height = sheet.itemsHeight
         if #available(iOS 10.0, *) {

--- a/Sheeeeeeeeet/Presenters/ActionSheetPopoverPresenter.swift
+++ b/Sheeeeeeeeet/Presenters/ActionSheetPopoverPresenter.swift
@@ -75,7 +75,7 @@ open class ActionSheetPopoverPresenter: NSObject, ActionSheetPresenter {
         let hasHeader = sheet.headerView != nil
         sheet.headerViewContainer?.isHidden = !hasHeader
         sheet.buttonsTableView?.isHidden = true
-        sheet.preferredContentSize.height = sheet.itemsHeight
+        sheet.preferredContentSize.height = sheet.itemsHeight + (hasHeader ? sheet.headerViewContainerHeight!.constant + 15 : 0)
         if #available(iOS 10.0, *) {
             refreshPopoverBackgroundColor()
         }


### PR DESCRIPTION
Header views were getting hidden on iPads.

Now: 

![](https://user-images.githubusercontent.com/1261982/59229231-d8867300-8ba7-11e9-81ca-c2f5f646bde3.png)
