### PR TITLE
Add support for auto-dismiss menu on didEnterBackground transition

### DIFF
--- a/SheeeeeeeeetDemo/Models/ActionSheetMenuOption.swift
+++ b/SheeeeeeeeetDemo/Models/ActionSheetMenuOption.swift
@@ -16,6 +16,7 @@ enum ActionSheetMenuOption {
     
     case
     danger,
+    dismissableOnDidEnterBackground,
     collections,
     customView,
     headerView,
@@ -32,6 +33,7 @@ enum ActionSheetMenuOption {
         case .collections: return "Collections"
         case .customView: return "Custom Views"
         case .danger: return "Destructive Actions"
+        case .dismissableOnDidEnterBackground: return "Dismissable onEnterBackground Sheets"
         case .headerView: return "Header Views"
         case .links: return "Links"
         case .multiSelect: return "Multi-Select Items"
@@ -48,6 +50,7 @@ enum ActionSheetMenuOption {
         case .collections: return "Open a collection-based sheet."
         case .customView: return "Open a sheet with a custom view."
         case .danger: return "Open a sheet with a destructive action."
+        case .dismissableOnDidEnterBackground: return "Open a sheet that will be dimsmissed when app enters background"
         case .headerView: return "Open a sheet with a header view."
         case .links: return "Open a sheet with links."
         case .multiSelect: return "Open a multi-select sheet."
@@ -68,6 +71,7 @@ enum ActionSheetMenuOption {
         case .collections: return "ic_view_module"
         case .customView: return "ic_custom"
         case .danger: return "ic_warning"
+        case .dismissableOnDidEnterBackground: return "ic_list"
         case .headerView: return "ic_header_view"
         case .links: return "ic_arrow_right"
         case .multiSelect: return "ic_checkmarks"

--- a/SheeeeeeeeetDemo/ViewController/ViewController+Menus.swift
+++ b/SheeeeeeeeetDemo/ViewController/ViewController+Menus.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Sheeeeeeeeet
 
 extension ViewController {
     
@@ -27,6 +28,9 @@ extension ViewController {
         case .openSheet(.singleSelect): return SingleSelectMenu(food: foodOptions)
         case .openSheet(.standard): return ItemMenu(food: foodOptions)
         case .openSheet(.nonDismissable): return ItemMenu(food: foodOptions, configuration: .nonDismissable)
+        case .openSheet(.dismissableOnDidEnterBackground):
+            let config = Menu.Configuration(isDismissable: true, shouldDismissOnDidEnterBackground: true)
+            return ItemMenu(food: foodOptions, configuration: config)
         }
     }
 }

--- a/SheeeeeeeeetDemo/ViewController/ViewController.swift
+++ b/SheeeeeeeeetDemo/ViewController/ViewController.swift
@@ -40,7 +40,8 @@ class ViewController: UIViewController {
             .openSheet(.collections),
             .openSheet(.customView),
             .openSheet(.danger),
-            .openSheet(.nonDismissable)
+            .openSheet(.nonDismissable),
+            .openSheet(.dismissableOnDidEnterBackground)
         ]
     }
     

--- a/Sources/Sheeeeeeeeet/ActionSheet/ActionSheet.swift
+++ b/Sources/Sheeeeeeeeet/ActionSheet/ActionSheet.swift
@@ -133,6 +133,7 @@ open class ActionSheet: UIViewController {
         }
         setup(items: items)
         presenter.isDismissable = menu.configuration.isDismissable
+        presenter.shouldDismissOnDidEnterBackground = menu.configuration.shouldDismissOnDidEnterBackground
     }
     
     

--- a/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetPopoverPresenter.swift
+++ b/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetPopoverPresenter.swift
@@ -32,6 +32,7 @@ open class ActionSheetPopoverPresenter: NSObject, ActionSheetPresenter {
     open var events = ActionSheetPresenterEvents()
     open var isDismissable = true
     open var isDismissableWithOrientationChange = true
+    open var shouldDismissOnDidEnterBackground = false
     
     
     // MARK: - Deprecated
@@ -45,9 +46,9 @@ open class ActionSheetPopoverPresenter: NSObject, ActionSheetPresenter {
     
     // MARK: - ActionSheetPresenter
     
-    @objc public func handleOrientationChange() {
-        dismiss {}
-    }
+    @objc public func handleOrientationChange() { dismiss {} }
+    
+    @objc public func handleDidEnterBackground() { dismiss {} }
     
     public func dismiss(completion: @escaping () -> ()) {
         let dismissAction = { completion();  self.actionSheet = nil }
@@ -73,6 +74,7 @@ open class ActionSheetPopoverPresenter: NSObject, ActionSheetPresenter {
         refreshPopoverBackgroundColor()
         vc.present(sheet, animated: true, completion: completion)
         setupOrientationChangeDetection()
+        setupDidEnterBackgroundDetection()
     }
     
     open func refreshActionSheet() {
@@ -98,6 +100,14 @@ open class ActionSheetPopoverPresenter: NSObject, ActionSheetPresenter {
         actionSheet?.backgroundView.isHidden = true
         actionSheet?.view.backgroundColor = ActionSheetTableView.appearance().backgroundColor
         popover?.backgroundColor = ActionSheetTableView.appearance().backgroundColor
+    }
+    
+    open func setupDidEnterBackgroundDetection(with center: NotificationCenter = .default) {
+        let action = #selector(handleDidEnterBackground)
+        let name = UIApplication.didEnterBackgroundNotification
+        center.removeObserver(self, name: name, object: nil)
+        guard isDismissable && shouldDismissOnDidEnterBackground else { return }
+        center.addObserver(self, selector: action, name: name, object: nil)
     }
     
     open func setupOrientationChangeDetection(with center: NotificationCenter = .default) {

--- a/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetPresenter.swift
+++ b/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetPresenter.swift
@@ -20,6 +20,7 @@ public protocol ActionSheetPresenter: AnyObject {
     
     var events: ActionSheetPresenterEvents { get set }
     var isDismissable: Bool { get set }
+    var shouldDismissOnDidEnterBackground: Bool { get set }
     
     func dismiss(completion: @escaping () -> Void)
     func present(sheet: ActionSheet, in vc: UIViewController, from view: UIView?, completion: @escaping () -> Void)

--- a/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetStandardPresenter.swift
+++ b/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetStandardPresenter.swift
@@ -32,6 +32,7 @@ open class ActionSheetStandardPresenter: ActionSheetPresenter {
     
     public var events = ActionSheetPresenterEvents()
     public var isDismissable = true
+    public var shouldDismissOnDidEnterBackground = false
     public var presentationStyle = PresentationStyle.currentContext
     
     var actionSheet: ActionSheet?
@@ -48,6 +49,8 @@ open class ActionSheetStandardPresenter: ActionSheetPresenter {
     
     // MARK: - ActionSheetPresenter
     
+    @objc public func handleDidEnterBackground() { dismiss {} }
+
     open func dismiss(completion: @escaping () -> ()) {
         completion()
         removeBackgroundView()
@@ -69,6 +72,7 @@ open class ActionSheetStandardPresenter: ActionSheetPresenter {
         actionSheet = sheet
         addActionSheet(sheet, to: vc)
         addBackgroundViewTapAction(to: sheet.backgroundView)
+        setupDidEnterBackgroundDetection()
         presentBackgroundView()
         presentActionSheet(completion: completion)
     }
@@ -130,6 +134,14 @@ open class ActionSheetStandardPresenter: ActionSheetPresenter {
         let animation = { view.alpha = 0 }
         animate(animation)
     }
+    
+    open func setupDidEnterBackgroundDetection(with center: NotificationCenter = .default) {
+           let action = #selector(handleDidEnterBackground)
+           let name = UIApplication.didEnterBackgroundNotification
+           center.removeObserver(self, name: name, object: nil)
+           guard isDismissable && shouldDismissOnDidEnterBackground else { return }
+           center.addObserver(self, selector: action, name: name, object: nil)
+       }
 }
 
 

--- a/Sources/Sheeeeeeeeet/Menu/MenuConfiguration.swift
+++ b/Sources/Sheeeeeeeeet/Menu/MenuConfiguration.swift
@@ -20,8 +20,9 @@ public extension Menu {
         /**
          Create a configuration instance.
          */
-        public init(isDismissable: Bool) {
+        public init(isDismissable: Bool, shouldDismissOnDidEnterBackground: Bool = false) {
             self.isDismissable = isDismissable
+            self.shouldDismissOnDidEnterBackground = shouldDismissOnDidEnterBackground
         }
         
         /**
@@ -29,6 +30,13 @@ public extension Menu {
          menu without using any of its options or buttons.
          */
         public let isDismissable: Bool
+
+        /**
+         Whether or not the menu should be dismissed when
+         the app transitions to background (didEnterBackground state).
+         This property is preceeded by `isDissmissable` property
+        */
+        public let shouldDismissOnDidEnterBackground: Bool
         
         /**
          The standard menu configuration that is used if you

--- a/Tests/SheeeeeeeeetTests/ActionSheet/ActionSheetTests.swift
+++ b/Tests/SheeeeeeeeetTests/ActionSheet/ActionSheetTests.swift
@@ -44,6 +44,7 @@ class ActionSheetTests: QuickSpec {
                     let sheet = ActionSheet(menu: menu, presenter: presenter) { _, _ in counter += 1 }
                     expect(sheet.presenter).to(be(presenter))
                     expect(sheet.presenter.isDismissable).to(beTrue())
+                    expect(sheet.presenter.shouldDismissOnDidEnterBackground).to(beFalse())
                     expect(sheet.items.count).to(equal(2))
                     expect(sheet.items[0] is MenuTitle).to(beTrue())
                     expect(sheet.items[0].title).to(equal("title"))
@@ -58,6 +59,21 @@ class ActionSheetTests: QuickSpec {
                     let menu = Menu(title: "title", items: [], configuration: .nonDismissable)
                     let sheet = ActionSheet(menu: menu) { _, _ in }
                     expect(sheet.presenter.isDismissable).to(beFalse())
+                    expect(sheet.presenter.shouldDismissOnDidEnterBackground).to(beFalse())
+                }
+                
+                it("can enable presenter auto-dismissal on didEnterBackground with menu configuration") {
+                    let config = Menu.Configuration(isDismissable: true, shouldDismissOnDidEnterBackground: true)
+                    let menu = Menu(title: "title", items: [], configuration: config)
+                    let sheet = ActionSheet(menu: menu) { _, _ in }
+                    expect(sheet.presenter.shouldDismissOnDidEnterBackground).to(beTrue())
+                }
+                
+                it("can disable presenter auto-dismissal on didEnterBackground with menu configuration") {
+                    let config = Menu.Configuration(isDismissable: true, shouldDismissOnDidEnterBackground: false)
+                    let menu = Menu(title: "title", items: [], configuration: config)
+                    let sheet = ActionSheet(menu: menu) { _, _ in }
+                    expect(sheet.presenter.shouldDismissOnDidEnterBackground).to(beFalse())
                 }
             }
         }

--- a/Tests/SheeeeeeeeetTests/ActionSheet/Mocks/MockActionSheetPresenter.swift
+++ b/Tests/SheeeeeeeeetTests/ActionSheet/Mocks/MockActionSheetPresenter.swift
@@ -14,6 +14,7 @@ class MockActionSheetPresenter: Mock, ActionSheetPresenter {
     
     var events = ActionSheetPresenterEvents()
     var isDismissable = false
+    var shouldDismissOnDidEnterBackground = false
     
     typealias PresentFromViewSignature = (ActionSheet, UIViewController, UIView?, @escaping () -> Void) -> Void
     typealias PresentFromItemSignature = (ActionSheet, UIViewController, UIBarButtonItem, @escaping () -> Void) -> Void

--- a/Tests/SheeeeeeeeetTests/ActionSheet/Presenters/ActionSheetPopoverPresenterTests.swift
+++ b/Tests/SheeeeeeeeetTests/ActionSheet/Presenters/ActionSheetPopoverPresenterTests.swift
@@ -49,6 +49,14 @@ class ActionSheetPopoverPresenterTests: QuickSpec {
         }
         
         
+        describe("auto-dismissal on didEnterBackground") {
+            
+            it("is disabled by default") {
+                expect(presenter.shouldDismissOnDidEnterBackground).to(beFalse())
+            }
+        }
+        
+        
         describe("dismissing") {
             
             it("completes dismissal directly if action sheet has no presenting view controller") {
@@ -207,6 +215,39 @@ class ActionSheetPopoverPresenterTests: QuickSpec {
             it("adds observer if presenter is listening for changes") {
                 presenter.isDismissableWithOrientationChange = true
                 presenter.setupOrientationChangeDetection(with: center)
+                expect(center.addObserverInvokeCount).to(equal(1))
+                expect(center.addObserverInvokeNames[0]).to(equal(expectedName))
+                expect(center.addObserverInvokeObjects[0]).to(beNil())
+            }
+        }
+        
+        
+        describe("setting up onDidEnterBackground detection") {
+            
+            var center: MockNotificationCenter!
+            let expectedName = UIApplication.didEnterBackgroundNotification
+            
+            beforeEach {
+                center = MockNotificationCenter()
+                presenter.isDismissable = true
+            }
+            
+            it("removes observer") {
+                presenter.setupDidEnterBackgroundDetection(with: center)
+                expect(center.removeObserverInvokeCount).to(equal(1))
+                expect(center.removeObserverInvokeNames[0]).to(equal(expectedName))
+                expect(center.removeObserverInvokeObjects[0]).to(beNil())
+            }
+            
+            it("does not add observer if presenter is not listening for changes") {
+                presenter.shouldDismissOnDidEnterBackground = false
+                presenter.setupDidEnterBackgroundDetection(with: center)
+                expect(center.addObserverInvokeCount).to(equal(0))
+            }
+            
+            it("adds observer if presenter is listening for changes") {
+                presenter.shouldDismissOnDidEnterBackground = true
+                presenter.setupDidEnterBackgroundDetection(with: center)
                 expect(center.addObserverInvokeCount).to(equal(1))
                 expect(center.addObserverInvokeNames[0]).to(equal(expectedName))
                 expect(center.addObserverInvokeObjects[0]).to(beNil())

--- a/Tests/SheeeeeeeeetTests/ActionSheet/Presenters/ActionSheetStandardPresenterTests.swift
+++ b/Tests/SheeeeeeeeetTests/ActionSheet/Presenters/ActionSheetStandardPresenterTests.swift
@@ -35,6 +35,41 @@ class ActionSheetStandardPresenterTests: QuickSpec {
         }
         
         
+        describe("auto-dismissal on didEnterBackground") {
+            
+            it("is disabled by default") {
+                expect(presenter.shouldDismissOnDidEnterBackground).to(beFalse())
+            }
+            
+            it("dismisses sheet when both isDismissable and shouldDismissOnDidEnterBackground are true") {
+                presenter.isDismissable = true
+                presenter.shouldDismissOnDidEnterBackground = true
+                
+                NotificationCenter.default.post(Notification(name: UIApplication.didEnterBackgroundNotification))
+                
+                expect(presenter.actionSheet).toEventually(beNil())
+            }
+            
+            it("does not dismiss sheet when shouldDismissOnDidEnterBackground is false") {
+                presenter.isDismissable = true
+                presenter.shouldDismissOnDidEnterBackground = false
+                
+                NotificationCenter.default.post(Notification(name: UIApplication.didEnterBackgroundNotification))
+                
+                expect(presenter.actionSheet).toNotEventually(beNil())
+            }
+            
+            it("does not dismiss sheet when isDismissable is false") {
+                presenter.isDismissable = false
+                presenter.shouldDismissOnDidEnterBackground = true
+                
+                NotificationCenter.default.post(Notification(name: UIApplication.didEnterBackgroundNotification))
+                
+                expect(presenter.actionSheet).toNotEventually(beNil())
+            }
+        }
+        
+        
         describe("dismissing action sheet") {
             
             var counter: Int!

--- a/Tests/SheeeeeeeeetTests/Menu/MenuConfigurationTests.swift
+++ b/Tests/SheeeeeeeeetTests/Menu/MenuConfigurationTests.swift
@@ -19,6 +19,7 @@ class MenuConfigurationTests: QuickSpec {
             it("can be dismissed") {
                 let config = Menu.Configuration.standard
                 expect(config.isDismissable).to(beTrue())
+                expect(config.shouldDismissOnDidEnterBackground).to(beFalse())
             }
         }
         
@@ -27,6 +28,7 @@ class MenuConfigurationTests: QuickSpec {
             it("can be dismissed") {
                 let config = Menu.Configuration.nonDismissable
                 expect(config.isDismissable).to(beFalse())
+                expect(config.shouldDismissOnDidEnterBackground).to(beFalse())
             }
         }
     }

--- a/Tests/SheeeeeeeeetTests/Menu/MenuTests.swift
+++ b/Tests/SheeeeeeeeetTests/Menu/MenuTests.swift
@@ -30,12 +30,14 @@ class MenuTests: QuickSpec {
                 let menu = Menu(items: [])
                 
                 expect(menu.configuration.isDismissable).to(beTrue())
+                expect(menu.configuration.shouldDismissOnDidEnterBackground).to(beFalse())
             }
             
             it("can use custom configuration") {
                 let menu = Menu(items: [], configuration: .nonDismissable)
                 
                 expect(menu.configuration.isDismissable).to(beFalse())
+                expect(menu.configuration.shouldDismissOnDidEnterBackground).to(beFalse())
             }
         }
     }


### PR DESCRIPTION
1. Listen for notifications UIApplication.didEnterBackgroundNotification and dismiss the context menu if the menu configuration dictates that

2. Extend Menu.Configuration with option `shouldDismissOnDidEnterBackground`. Default value is true

3. Add unit tests