### PR TITLE
[Feature] Is context menu active

### DIFF
--- a/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
+++ b/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
@@ -61,7 +61,12 @@ public class ContextMenuDelegate: NSObject, UIContextMenuInteractionDelegate {
     
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         UIContextMenuConfiguration(identifier: nil, previewProvider: previewProvider, actionProvider: { [weak self] _ in
-            guard let self = self else { fatalError("ContextMenuDelegate was deallocated") }
+            guard let self = self else {
+                #if DEBUG
+                print("ContextMenuDelegate was deallocated")
+                #endif
+                return nil
+            }
             let menu = self.menuCreator.createMenu()
             switch menu.toContextMenu(action: self.action) {
             case .failure(let error): fatalError(error.localizedDescription)

--- a/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
+++ b/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
@@ -72,6 +72,11 @@ public class ContextMenuDelegate: NSObject, UIContextMenuInteractionDelegate {
             }
         })
     }
+    
+    public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, willEndFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?) {
+        activeInteraction = nil
+        activeConfiguration = nil
+    }
 }
 
 

--- a/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
+++ b/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
@@ -56,7 +56,7 @@ public class ContextMenuDelegate: NSObject, UIContextMenuInteractionDelegate {
     let action: (MenuItem) -> ()
     let previewProvider: UIContextMenuContentPreviewProvider?
     
-    weak var activeInteraction: UIContextMenuInteraction?
+    public internal(set) weak var activeInteraction: UIContextMenuInteraction?
     var activeConfiguration: ContextMenu.Configuration?
     
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {

--- a/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
+++ b/Sources/Sheeeeeeeeet/ContextMenu/ContextMenuDelegate.swift
@@ -56,8 +56,10 @@ public class ContextMenuDelegate: NSObject, UIContextMenuInteractionDelegate {
     let action: (MenuItem) -> ()
     let previewProvider: UIContextMenuContentPreviewProvider?
     
-    public internal(set) weak var activeInteraction: UIContextMenuInteraction?
+    weak var activeInteraction: UIContextMenuInteraction?
     var activeConfiguration: ContextMenu.Configuration?
+    
+    public var isCurrentlyPresented: Bool { return activeInteraction != nil }
     
     public func contextMenuInteraction(_ interaction: UIContextMenuInteraction, configurationForMenuAtLocation location: CGPoint) -> UIContextMenuConfiguration? {
         UIContextMenuConfiguration(identifier: nil, previewProvider: previewProvider, actionProvider: { [weak self] _ in

--- a/Tests/SheeeeeeeeetTests/ContextMenu/Menu+ContextMenuTests.swift
+++ b/Tests/SheeeeeeeeetTests/ContextMenu/Menu+ContextMenuTests.swift
@@ -141,6 +141,40 @@ class Menu_ContextMenuTests: QuickSpec {
                 expect(removeExecutions.count).to(equal(0))
             }
         }
+        
+        describe("isCurrentlyPresented") {
+            
+            it("is true when activeInteraction has value") {
+                guard #available(iOS 13.0, *) else { return }
+                let view = TestView()
+                view.shouldCallSuper = true
+                let menu = Menu(title: "title", items: [])
+                menu.addAsRetainedContextMenu(to: view) { _ in }
+                
+                guard let interaction = view.interactions.first as? UIContextMenuInteraction,
+                    let delegate = view.contextMenuDelegate as? ContextMenuDelegate else {
+                        return fail("interactor or delegate not set")
+                }
+                
+                delegate.activeInteraction = interaction
+                expect(delegate.isCurrentlyPresented).to(beTrue())
+            }
+            
+            it("is false when activeInteraction is nil") {
+                guard #available(iOS 13.0, *) else { return }
+                let view = TestView()
+                view.shouldCallSuper = true
+                let menu = Menu(title: "title", items: [])
+                menu.addAsRetainedContextMenu(to: view) { _ in }
+                
+                guard let delegate = view.contextMenuDelegate as? ContextMenuDelegate else {
+                    return fail("delegate not set")
+                }
+                
+                delegate.activeInteraction = nil
+                expect(delegate.isCurrentlyPresented).to(beFalse())
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Today there is no way to find out if the native UIContextMenu is shown or not.

But by adding a computed property called `isCurrentlyPresented` that uses `activeInteraction` in `ContextMenuDelegate.swift` and by resetting `activeInteraction` in the callback method for when the context menu is being dismissed, it will be possible to find that out.

Delegate callback method used to reset the property activeInteraction
`contextMenuInteraction(_ interaction: UIContextMenuInteraction, willEndFor configuration: UIContextMenuConfiguration, animator: UIContextMenuInteractionAnimating?)`
