### PR TITLE
Prevent multiple dismiss

### DIFF
--- a/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetPopoverPresenter.swift
+++ b/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetPopoverPresenter.swift
@@ -39,10 +39,9 @@ open class ActionSheetPopoverPresenter: ActionSheetPresenterBase {
     open override func dismiss(completion: @escaping () -> ()) {
         let dismissAction = { completion();  self.actionSheet = nil }
         let presenter = actionSheet?.presentingViewController
-        guard !(actionSheet?.isBeingDismissed ?? true) else {
-            return
+        if !(actionSheet?.isBeingDismissed ?? true) {
+            presenter?.dismiss(animated: true) { dismissAction() } ?? dismissAction()
         }
-        presenter?.dismiss(animated: true) { dismissAction() } ?? dismissAction()
     }
     
     open override func present(_ sheet: ActionSheet, in vc: UIViewController, view: UIView? = nil, item: UIBarButtonItem? = nil, completion: @escaping () -> ()) {


### PR DESCRIPTION
I have an issue with this part of code when using you library with BlackBerry Dynamics SDK because it uses a lot of iOS code swizzling and it ended up in posting status bar changed notification 3 times for one rotation. So without this check my application ends up in dismissing actionSheet?.presentingViewController itself on every rotation. Also I suppose it maybe somehow reproduced by quickly rotating device back and forth but I am not sure. 