### PR TITLE
Calculate the intrinsic content height before presenting sheets

### DIFF
--- a/Sources/Sheeeeeeeeet/ActionSheet/ActionSheet.swift
+++ b/Sources/Sheeeeeeeeet/ActionSheet/ActionSheet.swift
@@ -186,6 +186,8 @@ open class ActionSheet: UIViewController {
     
     let stackView = ActionSheetStackView()
     
+    public var intrinsicContentHeight: Double { itemsHeight + buttonsHeight + sectionMargins }
+    
     let headerViewContainer = ActionSheetHeaderContainerView()
     var itemsTableView = ActionSheetItemTableView()
     var buttonsTableView = ActionSheetButtonTableView()

--- a/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetStandardPresenter.swift
+++ b/Sources/Sheeeeeeeeet/ActionSheet/Presenters/ActionSheetStandardPresenter.swift
@@ -90,10 +90,10 @@ open class ActionSheetStandardPresenter: ActionSheetPresenterBase {
     }
     
     open func presentActionSheet(completion: @escaping () -> ()) {
-        guard let view = actionSheet?.stackView else { return }
-        let frame = view.frame
-        view.frame.origin.y += frame.height + 100
-        let animation = { view.frame = frame }
+        guard let actionSheet = actionSheet else { return }
+        let view = actionSheet.stackView
+        view.frame.origin.y += actionSheet.intrinsicContentHeight + 100
+        let animation = { view.frame.origin = .zero }
         animate(animation, completion: completion)
     }
     

--- a/Tests/SheeeeeeeeetTests/ActionSheet/Presenters/ActionSheetStandardPresenterTests.swift
+++ b/Tests/SheeeeeeeeetTests/ActionSheet/Presenters/ActionSheetStandardPresenterTests.swift
@@ -86,7 +86,7 @@ class ActionSheetStandardPresenterTests: QuickSpec {
                 sheet.viewDidLoad()
                 presenter.animationDuration = -1
                 presenter.present(sheet, in: vc) {}
-                expect(sheet.stackView.frame.origin.y).to(equal(100))
+                expect(sheet.stackView.frame.origin.y).to(equal(sheet.intrinsicContentHeight + 100))
             }
         }
     }


### PR DESCRIPTION
Trying to fix https://github.com/danielsaidi/Sheeeeeeeeet/issues/154

View frame is empty in `presentActionSheet(completion:)` because stackView's actual frame is not ready yet.

Since we already know the heights of everything inside stackView, we can calculate the intrinsic height ourselves.

Also, we no longer need to change the whole `frame` property of `view` within animation but just the `origin` to be `.zero`