### PR TITLE
Update the minimum development target

### DIFF
--- a/Sheeeeeeeeet.xcodeproj/project.pbxproj
+++ b/Sheeeeeeeeet.xcodeproj/project.pbxproj
@@ -1913,6 +1913,7 @@
 					"$(SRCROOT)/.build/checkouts/Quick/Sources/QuickSpecBase/include",
 				);
 				INFOPLIST_FILE = Sheeeeeeeeet.xcodeproj/SheeeeeeeeetTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../Frameworks",
@@ -1942,6 +1943,7 @@
 					"$(SRCROOT)/.build/checkouts/Quick/Sources/QuickSpecBase/include",
 				);
 				INFOPLIST_FILE = Sheeeeeeeeet.xcodeproj/SheeeeeeeeetTests_Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@loader_path/../Frameworks",


### PR DESCRIPTION
Hi,

This PR updates the minimum development target of the unit test target to resolve the following build error:

```
error build: Compiling for iOS 9.0, but module 'Quick' has a minimum deployment target of iOS 11.0: /Users/woxtu/Library/Developer/Xcode/DerivedData/Sheeeeeeeeet-exicvdxyasypieanrmorlbsbakft/Build/Products/Debug-iphonesimulator/Quick.swiftmodule/x86_64-apple-ios-simulator.swiftmodule
```